### PR TITLE
Install Python in test-coverage CI and revert PANDA.R debug code

### DIFF
--- a/.github/workflows/bioc-check.yml
+++ b/.github/workflows/bioc-check.yml
@@ -183,6 +183,22 @@ jobs:
             any::covr
             any::reticulate
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Python packages
+        run: |
+          pip install --upgrade pip
+          pip install numpy scipy pandas
+        shell: bash
+
+      - name: Set RETICULATE_PYTHON
+        run: |
+          echo "RETICULATE_PYTHON=$(python -c 'import sys; print(sys.executable)')" >> $GITHUB_ENV
+        shell: bash
+
       - name: Test coverage
         run: |
           covr::codecov(quiet = FALSE)

--- a/R/PANDA.R
+++ b/R/PANDA.R
@@ -134,21 +134,6 @@ pandaPy <- function(expr_file, motif_file=NULL, ppi_file=NULL, computing="cpu", 
   
   # source the pypanda from github raw website.
   pandapath <- system.file("extdata", "panda.py", package = "netZooR", mustWork = TRUE)
-  message("pandapath: ", pandapath)
-  message("exists: ", file.exists(pandapath))
-  message("python: ", reticulate::py_config()$python)
-  tryCatch(
-    reticulate::source_python(pandapath, convert = TRUE),
-    error = function(e) {
-      cat("source_python failed:")
-      cat(conditionMessage(e))
-      
-      cat("reticulate Python error:")
-      cat(reticulate::py_last_error())
-      flush.console()
-      stop(e)
-    }
-  )
   reticulate::source_python(pandapath,convert = TRUE)
   
   # invoke Python script to create a Panda object


### PR DESCRIPTION
Targets PR netZoo/netZooR#404 so it absorbs this fix and CI goes green.

## Root cause

Two issues, chained:

1. The `test-coverage` job in `.github/workflows/bioc-check.yml` had no Python setup, so `reticulate::source_python(panda.py)` failed when its imports (numpy/scipy/pandas) were unavailable. The `bioc-check` job already does this; `test-coverage` was the only job missing it.
2. The diagnostic `tryCatch` added to `R/PANDA.R` had its own bug — `cat(reticulate::py_last_error())` crashes because `py_last_error()` returns a list, not a character vector. This is what produced the visible `FAIL 1` in testthat and masked the real Python import error.

## Changes

- `.github/workflows/bioc-check.yml` — added `actions/setup-python@v5`, `pip install numpy scipy pandas`, and a `RETICULATE_PYTHON` env-var step to the `test-coverage` job, mirroring `bioc-check`.
- `R/PANDA.R` — reverted the diagnostic block in `pandaPy()` (three `message()` lines, broken `tryCatch`, and the duplicate trailing `source_python()` call) back to the original two lines. The diagnostic served its purpose; we now know the cause.

## Test plan

- [ ] CI: `test-coverage` job passes on PR #404 after this is merged in.
- [ ] CI: All four `bioc-check` matrix jobs continue to pass.
- [ ] Local sanity (optional): `R CMD build . && R CMD check netZooR_*.tar.gz --no-manual --no-vignettes`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)